### PR TITLE
Replace broadcast transaction with add transaction

### DIFF
--- a/crates/networking/src/rpc_abi.rs
+++ b/crates/networking/src/rpc_abi.rs
@@ -1,6 +1,6 @@
 use axum::{response::IntoResponse, Json};
 use constants::IRON_NATIVE_ASSET;
-use serde::{ Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use ureq::json;
 
 use crate::orescriptions::{get_ores, is_ores_local, Ores};
@@ -13,7 +13,7 @@ pub struct RpcResponse<T> {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RpcResponseStream<T> {
-    pub data: T
+    pub data: T,
 }
 
 impl<T: Serialize> IntoResponse for RpcResponse<T> {
@@ -232,15 +232,14 @@ pub struct RpcCreateTxResponse {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct RpcBroadcastTxRequest {
+pub struct RpcAddTransactionRequest {
     pub transaction: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct RpcBroadcastTxResponse {
+pub struct RpcAddTransactionResponse {
     pub hash: String,
     pub accepted: bool,
-    pub broadcasted: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/networking/src/rpc_handler/handler.rs
+++ b/crates/networking/src/rpc_handler/handler.rs
@@ -8,9 +8,18 @@ use ureq::{Agent, AgentBuilder, Error, Response};
 
 use crate::{
     rpc_abi::{
-        RpcBroadcastTxRequest, RpcBroadcastTxResponse, RpcCreateTxRequest, RpcCreateTxResponse, RpcExportAccountResponse, RpcGetAccountStatusRequest, RpcGetAccountStatusResponse, RpcGetAccountTransactionRequest, RpcGetAccountTransactionResponse, RpcGetBalancesRequest, RpcGetBalancesResponse, RpcGetBlockRequest, RpcGetBlockResponse, RpcGetBlocksRequest, RpcGetBlocksResponse, RpcGetLatestBlockResponse, RpcGetTransactionsRequest, RpcGetTransactionsResponse, RpcImportAccountRequest, RpcImportAccountResponse, RpcRemoveAccountRequest, RpcRemoveAccountResponse, RpcResetAccountRequest, RpcResponse, RpcSetAccountHeadRequest, RpcSetScanningRequest, SendTransactionRequest, SendTransactionResponse, TransactionStatus
+        RpcAddTransactionRequest, RpcAddTransactionResponse, RpcCreateTxRequest,
+        RpcCreateTxResponse, RpcExportAccountResponse, RpcGetAccountStatusRequest,
+        RpcGetAccountStatusResponse, RpcGetAccountTransactionRequest,
+        RpcGetAccountTransactionResponse, RpcGetBalancesRequest, RpcGetBalancesResponse,
+        RpcGetBlockRequest, RpcGetBlockResponse, RpcGetBlocksRequest, RpcGetBlocksResponse,
+        RpcGetLatestBlockResponse, RpcGetTransactionsRequest, RpcGetTransactionsResponse,
+        RpcImportAccountRequest, RpcImportAccountResponse, RpcRemoveAccountRequest,
+        RpcRemoveAccountResponse, RpcResetAccountRequest, RpcResponse, RpcSetAccountHeadRequest,
+        RpcSetScanningRequest, SendTransactionRequest, SendTransactionResponse, TransactionStatus,
     },
-    rpc_handler::RpcError, stream::RequestExt,
+    rpc_handler::RpcError,
+    stream::RequestExt,
 };
 
 #[derive(Debug, Clone)]
@@ -35,7 +44,8 @@ impl RpcHandler {
         request: RpcImportAccountRequest,
     ) -> Result<RpcResponse<RpcImportAccountResponse>, OreoError> {
         let path = format!("http://{}/wallet/importAccount", self.endpoint);
-        let account_str = serde_json::to_string(&request).map_err(|_|OreoError::InternalRpcError("JSON serialization failed".to_string()))?;
+        let account_str = serde_json::to_string(&request)
+            .map_err(|_| OreoError::InternalRpcError("JSON serialization failed".to_string()))?;
         let resp = self
             .agent
             .clone()
@@ -129,20 +139,19 @@ impl RpcHandler {
         let resp = self.agent.clone().post(&path).send_json(&request);
         handle_response(resp)
     }
-    
+
     pub fn get_transactions(
         &self,
         request: RpcGetTransactionsRequest,
     ) -> Result<RpcResponse<RpcGetTransactionsResponse>, OreoError> {
         let path = format!("http://{}/wallet/getAccountTransactions", self.endpoint);
         let resp = self.agent.clone().post(&path).send_json(&request);
-    
+
         match resp {
             Ok(response) => {
-                let transactions: Result<Vec<_>, OreoError> = response
-                    .into_stream::<TransactionStatus>()
-                    .collect();
-    
+                let transactions: Result<Vec<_>, OreoError> =
+                    response.into_stream::<TransactionStatus>().collect();
+
                 Ok(RpcResponse {
                     status: 200,
                     data: RpcGetTransactionsResponse {
@@ -163,11 +172,11 @@ impl RpcHandler {
         handle_response(resp)
     }
 
-    pub fn broadcast_transaction(
+    pub fn add_transaction(
         &self,
-        request: RpcBroadcastTxRequest,
-    ) -> Result<RpcResponse<RpcBroadcastTxResponse>, OreoError> {
-        let path = format!("http://{}/chain/broadcastTransaction", self.endpoint);
+        request: RpcAddTransactionRequest,
+    ) -> Result<RpcResponse<RpcAddTransactionResponse>, OreoError> {
+        let path = format!("http://{}/wallet/addTransaction", self.endpoint);
         let resp = self.agent.clone().post(&path).send_json(&request);
         handle_response(resp)
     }
@@ -201,7 +210,11 @@ impl RpcHandler {
             .agent
             .clone()
             .post(&path)
-            .send_json(RpcGetBlocksRequest { start, end, serialized: true });
+            .send_json(RpcGetBlocksRequest {
+                start,
+                end,
+                serialized: true,
+            });
         handle_response(resp)
     }
 

--- a/crates/server/src/handlers.rs
+++ b/crates/server/src/handlers.rs
@@ -8,12 +8,15 @@ use axum::{
 use constants::{ACCOUNT_VERSION, MAINNET_GENESIS_SEQUENCE};
 use db_handler::DBHandler;
 use networking::{
-    decryption_message::{DecryptionMessage, ScanRequest, ScanResponse, SuccessResponse}, rpc_abi::{
-        BlockInfo, OutPut, RpcBroadcastTxRequest, RpcCreateTxRequest, RpcGetAccountStatusRequest,
-        RpcGetAccountTransactionRequest, RpcGetBalancesRequest, RpcGetBalancesResponse,
-        RpcGetTransactionsRequest, RpcImportAccountRequest, RpcImportAccountResponse,
-        RpcRemoveAccountRequest, RpcResetAccountRequest, RpcResponse, RpcSetScanningRequest,
-    }, web_abi::{GetTransactionDetailResponse, ImportAccountRequest, RescanAccountResponse}
+    decryption_message::{DecryptionMessage, ScanRequest, ScanResponse, SuccessResponse},
+    rpc_abi::{
+        BlockInfo, OutPut, RpcAddTransactionRequest, RpcCreateTxRequest,
+        RpcGetAccountStatusRequest, RpcGetAccountTransactionRequest, RpcGetBalancesRequest,
+        RpcGetBalancesResponse, RpcGetTransactionsRequest, RpcImportAccountRequest,
+        RpcImportAccountResponse, RpcRemoveAccountRequest, RpcResetAccountRequest, RpcResponse,
+        RpcSetScanningRequest,
+    },
+    web_abi::{GetTransactionDetailResponse, ImportAccountRequest, RescanAccountResponse},
 };
 use oreo_errors::OreoError;
 use serde_json::json;
@@ -258,7 +261,8 @@ pub async fn update_scan_status_handler<T: DBHandler>(
                 return e.into_response();
             }
             let account = db_account.unwrap();
-            let reset_created_at = account.create_head.is_none() || account.create_head.unwrap() == 1;
+            let reset_created_at =
+                account.create_head.is_none() || account.create_head.unwrap() == 1;
             let reset = shared.rpc_handler.reset_account(RpcResetAccountRequest {
                 account: account.name.clone(),
                 reset_scanning_enabled: Some(false),
@@ -436,13 +440,13 @@ pub async fn create_transaction_handler<T: DBHandler>(
         .into_response()
 }
 
-pub async fn broadcast_transaction_handler<T: DBHandler>(
+pub async fn add_transaction_handler<T: DBHandler>(
     State(shared): State<Arc<SharedState<T>>>,
-    extract::Json(broadcast_transaction): extract::Json<RpcBroadcastTxRequest>,
+    extract::Json(add_transaction): extract::Json<RpcAddTransactionRequest>,
 ) -> impl IntoResponse {
     shared
         .rpc_handler
-        .broadcast_transaction(broadcast_transaction)
+        .add_transaction(add_transaction)
         .into_response()
 }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,11 +1,21 @@
-use std::{env, net::SocketAddr, sync::Arc, time::Duration};
-use axum_extra::{headers::{authorization::Basic, Authorization}, TypedHeader};
-use sha2::{Sha256, Digest};
+use axum_extra::{
+    headers::{authorization::Basic, Authorization},
+    TypedHeader,
+};
+use sha2::{Digest, Sha256};
 use std::str;
+use std::{env, net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::Result;
 use axum::{
-    body::Body, error_handling::HandleErrorLayer, extract::State, http::{Request, StatusCode}, middleware::{from_fn_with_state,  Next}, response::IntoResponse, routing::{get, post}, BoxError, Router
+    body::Body,
+    error_handling::HandleErrorLayer,
+    extract::State,
+    http::{Request, StatusCode},
+    middleware::{from_fn_with_state, Next},
+    response::IntoResponse,
+    routing::{get, post},
+    BoxError, Router,
 };
 use db_handler::{DBHandler, PgHandler};
 use networking::{rpc_handler::RpcHandler, server_handler::ServerHandler};
@@ -15,7 +25,7 @@ use tower_http::cors::{Any, CorsLayer};
 use tracing::info;
 
 use crate::handlers::{
-    account_status_handler, broadcast_transaction_handler, create_transaction_handler,
+    account_status_handler, add_transaction_handler, create_transaction_handler,
     get_balances_handler, get_ores_handler, get_transaction_handler, get_transactions_handler,
     health_check_handler, import_account_handler, latest_block_handler, remove_account_handler,
     rescan_account_handler, update_scan_status_handler,
@@ -42,7 +52,13 @@ impl<T> SharedState<T>
 where
     T: DBHandler,
 {
-    pub fn new(db_handler: T, endpoint: &str, scan: &str, secp: SecpKey, genesis_hash: String) -> Self {
+    pub fn new(
+        db_handler: T,
+        endpoint: &str,
+        scan: &str,
+        secp: SecpKey,
+        genesis_hash: String,
+    ) -> Self {
         Self {
             db_handler: db_handler,
             rpc_handler: RpcHandler::new(endpoint.into()),
@@ -56,15 +72,20 @@ where
 pub async fn auth<T: DBHandler>(
     State(shared_state): State<Arc<SharedState<T>>>,
     TypedHeader(Authorization(basic)): TypedHeader<Authorization<Basic>>,
-    req: Request<Body>, 
-    next: Next
-) -> impl IntoResponse 
-    where
+    req: Request<Body>,
+    next: Next,
+) -> impl IntoResponse
+where
     T: DBHandler + Send + Sync + 'static,
 {
-    match shared_state.db_handler.get_account(basic.username().to_string()).await {
+    match shared_state
+        .db_handler
+        .get_account(basic.username().to_string())
+        .await
+    {
         Ok(account) => {
-            let bytes = hex::decode(account.vk).map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid token"))?;
+            let bytes =
+                hex::decode(account.vk).map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid token"))?;
             let token = Sha256::digest(bytes);
             let token_hex = hex::encode(token);
             if token_hex != basic.password() {
@@ -78,7 +99,7 @@ pub async fn auth<T: DBHandler>(
         }
     }
 }
-  
+
 pub async fn run_server(
     listen: SocketAddr,
     rpc_server: String,
@@ -116,7 +137,8 @@ pub async fn run_server(
         .route("/getTransaction", post(get_transaction_handler))
         .route("/getTransactions", post(get_transactions_handler))
         .route("/createTx", post(create_transaction_handler))
-        .route("/broadcastTx", post(broadcast_transaction_handler))
+        .route("/broadcastTx", post(add_transaction_handler)) // TODO: Remove once front end is updated to addTx
+        .route("/addTx", post(add_transaction_handler))
         .route("/accountStatus", post(account_status_handler))
         .route("/latestBlock", get(latest_block_handler))
         .route("/ores", post(get_ores_handler))
@@ -128,7 +150,7 @@ pub async fn run_server(
     if env::var("ENABLE_AUTH").unwrap_or_else(|_| "false".to_string()) == "true" {
         auth_router = auth_router.layer(auth_middleware);
     }
-        
+
     let router = no_auth_router
         .merge(auth_router)
         .layer(


### PR DESCRIPTION
Broadcast transaction does not add the transaction to the wallet's own pending transactions. Add does this and by default also broadcasts the transaction.